### PR TITLE
add setBus() for updating i2c bus

### DIFF
--- a/Wire.cpp
+++ b/Wire.cpp
@@ -163,3 +163,9 @@ void TwoWire::setClock(uint32_t)
     // TODO
 
 }
+
+void TwoWire::setBus(std::string bus)
+{
+    // TODO handle case where begin() has already been called
+    _bus = bus;
+}

--- a/include/Wire.h
+++ b/include/Wire.h
@@ -32,6 +32,7 @@ public:
         _pageBytes = bytes;
     }
     
+
     void begin();
     void beginTransmission(uint16_t id);
     uint8_t endTransmission(bool end = false);
@@ -53,6 +54,7 @@ public:
     }
 
     void setClock(uint32_t clock);
+    void setBus(std::string bus);
 };
 
 


### PR DESCRIPTION
In certain scenarios we need to be able to change the bus before begin() is called.